### PR TITLE
Various fixes to make this useful again

### DIFF
--- a/config/Copyrightcompliance.php
+++ b/config/Copyrightcompliance.php
@@ -8,7 +8,8 @@ return [
         'sender_map'    => [
             '/@copyright-compliance.com/',
             '/noreply@p2p.copyright-notice.com/',
-            '/notices@entura-international.co.uk/'
+            '/notices@entura-international.co.uk/',
+            '/p2p@.*\.copyright-notice.com/'
         ],
         'body_map'      => [
             //

--- a/src/Copyrightcompliance.php
+++ b/src/Copyrightcompliance.php
@@ -35,13 +35,13 @@ class Copyrightcompliance extends Parser
         foreach ($this->parsedMail->getAttachments() as $attachment) {
             // Only use the Copyrightcompliance formatted reports, skip all others
             if (preg_match(config("{$this->configBase}.parser.report_file"), $attachment->getFilename()) &&
-                $attachment->contentType == 'application/xml'
+                $attachment->getContentType() == 'application/xml'
             ) {
                 $foundAcnsFile = true;
 
                 $xmlReport = $attachment->getContent();
 
-                $this->saveIncidents($xmlReport);
+                $this->saveIncident($xmlReport);
             }
         }
 


### PR DESCRIPTION
Fixes the following:
- Adds new source to sender_map ('/p2p@.*\.copyright-notice.com/')
- Fixes, the Cannot access protected property PhpMimeMailParser\Attachment::$contentType
- Fixes typo in the saveIncidents() function name, should be saveIncident();