### PR TITLE
Adding p2p@copyright-notice.com to the sender_map

### DIFF
--- a/config/Copyrightcompliance.php
+++ b/config/Copyrightcompliance.php
@@ -9,7 +9,8 @@ return [
             '/@copyright-compliance.com/',
             '/noreply@p2p.copyright-notice.com/',
             '/notices@entura-international.co.uk/',
-            '/p2p@.*\.copyright-notice.com/'
+            '/p2p@.*\.copyright-notice.com/',
+            '/p2p@copyright-notice.com/'
         ],
         'body_map'      => [
             //


### PR DESCRIPTION
Adding `p2p@copyright-notice.com` to the `sender_map`.

As of the past few days, I am seeing several emails from this new address, i.e.

```
From: Vobile Compliance <p2p@copyright-notice.com>
```

Please bump and release a new version when this is merged.